### PR TITLE
Update Matchbot to JDA 

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This project's structure is a modified version of [Bolty](https://github.com/app
 
 MatchBot will listen to [`MatchStartEvent`](https://github.com/PGMDev/PGM/blob/dev/core/src/main/java/tc/oc/pgm/api/match/event/MatchStartEvent.java) and [`MatchFinishEvent`](https://github.com/PGMDev/PGM/blob/dev/core/src/main/java/tc/oc/pgm/api/match/event/MatchFinishEvent.java) to populate a Discord [embed](https://javacord.org/wiki/basic-tutorials/embeds.html#creating-an-embed) with information about a started or finished match.
 
-MatchBot is built with [Javacord](https://javacord.org/), an awesome Java library for Discord bots.
+MatchBot is built with [JDA](https://jda.wiki/), an awesome Java library for Discord bots.
 
 This bot runs on a single Minecraft server, and is not designed with proxies, networks, or multiple servers in mind.
 
@@ -49,12 +49,18 @@ You can also find out how to get server, role or channel IDs [here](https://supp
 ## Config
     
 ```yaml
-# Discord Stuff
-enabled: true # Enable discord bot?
+# MatchBot configuration file
+# Discord settings
+enabled: true # Enable Discord bot?
 token: "" # Discord bot token
-server: "" # ID of discord server
+server: "" # ID of Discord server
+match-channel: "" # ID of channel where match embeds will be sent
 
-# ID of channel where match embeds will be sent
-match-channel: ""
+# Minecraft settings
+server-name: "" # Name of the server (useful for networks)
+
+# Image URL to display in the embed's thumbnail if a map image is not found
+# Example: https://raw.githubusercontent.com/TBG1000/MapImages/main/map_image_not_found.png
+map-image-not-found: ""
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>MatchBot</artifactId>
     <version>1.0.0-SNAPSHOT</version>
     <name>MatchBot</name>
-    <description>A minecraft to discord java plugin</description>
+    <description>A Minecraft-to-Discord bot to display PGM match information in a channel.</description>
 
     <!-- Repository Locations -->
     <repositories>
@@ -43,12 +43,18 @@
         <dependency>
             <groupId>net.dv8tion</groupId>
             <artifactId>JDA</artifactId>
-            <version>5.0.0-beta.24</version>
+            <version>6.2.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>club.minnced</groupId>
+                    <artifactId>opus-java</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
     <build>
         <resources>
-            <!-- Include the required plugin.yml and config.yml for Bukkit -->
+            <!-- Include the required files for Bukkit -->
             <resource>
                 <directory>${basedir}/src/main/resources</directory>
                 <filtering>true</filtering>
@@ -123,7 +129,7 @@
             <plugin>
                 <groupId>com.diffplug.spotless</groupId>
                 <artifactId>spotless-maven-plugin</artifactId>
-                <version>2.43.0</version>
+                <version>3.1.0</version>
                 <configuration>
                     <ratchetFrom>origin/dev</ratchetFrom>
                     <java>

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.3</version>
+                <version>3.6.1</version>
                 <configuration>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
                     <minimizeJar>true</minimizeJar>

--- a/src/main/java/me/tbg/match/bot/BotConfig.java
+++ b/src/main/java/me/tbg/match/bot/BotConfig.java
@@ -9,7 +9,7 @@ public class BotConfig {
     private String token;
     private String serverId;
     private String matchChannel;
-    private String fallbackMapImages;
+    private String serverName;
     private String mapImageNotFound;
 
     public BotConfig(Configuration config) {
@@ -21,7 +21,7 @@ public class BotConfig {
         this.token = config.getString("token");
         this.serverId = config.getString("server");
         this.matchChannel = config.getString("match-channel");
-        this.fallbackMapImages = config.getString("fallback-map-images");
+        this.serverName = config.getString("server-name");
         this.mapImageNotFound = config.getString("map-image-not-found");
     }
 
@@ -41,9 +41,7 @@ public class BotConfig {
         return matchChannel;
     }
 
-    public String getFallbackMapImages() {
-        return fallbackMapImages;
-    }
+    public String getServerName() { return serverName; }
 
     public String getMapImageNotFound() {
         return mapImageNotFound;

--- a/src/main/java/me/tbg/match/bot/DiscordBot.java
+++ b/src/main/java/me/tbg/match/bot/DiscordBot.java
@@ -85,6 +85,9 @@ public class DiscordBot {
     public void sendMatchEmbed(EmbedBuilder embed, Match match) {
         if (api != null) {
             api.getPresence().setActivity(Activity.playing("Playing " + match.getMap().getName() + " on " + config.getServerName()));
+            if (config.getServerName().isEmpty()) {
+                api.getPresence().setActivity(Activity.playing("Playing " + match.getMap().getName()));
+            }
             Guild guild = api.getGuildById(config.getServerId());
             if (guild != null) {
                 TextChannel textChannel = guild.getTextChannelById(config.getMatchChannel());

--- a/src/main/java/me/tbg/match/bot/DiscordBot.java
+++ b/src/main/java/me/tbg/match/bot/DiscordBot.java
@@ -135,8 +135,8 @@ public class DiscordBot {
 
     public String parseDuration(Duration duration) {
         long hours = duration.toHours();
-        long minutes = duration.toMinutes();
-        long seconds = duration.getSeconds();
+        long minutes = duration.toMinutes() % 60;
+        long seconds = duration.getSeconds() % 60;
 
         StringBuilder result = new StringBuilder();
 

--- a/src/main/java/me/tbg/match/bot/DiscordBot.java
+++ b/src/main/java/me/tbg/match/bot/DiscordBot.java
@@ -18,6 +18,7 @@ import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import net.dv8tion.jda.api.requests.GatewayIntent;
+import net.dv8tion.jda.api.requests.restaction.MessageCreateAction;
 import net.dv8tion.jda.api.utils.AttachedFile;
 import net.dv8tion.jda.api.utils.FileUpload;
 import net.dv8tion.jda.api.utils.messages.MessageCreateBuilder;
@@ -83,23 +84,17 @@ public class DiscordBot {
 
     public void sendMatchEmbed(EmbedBuilder embed, Match match) {
         if (api != null) {
-            api.getPresence().setActivity(Activity.playing(match.getMap().getName()));
+            api.getPresence().setActivity(Activity.playing("Playing " + match.getMap().getName() + " on " + config.getServerName()));
             Guild guild = api.getGuildById(config.getServerId());
             if (guild != null) {
                 TextChannel textChannel = guild.getTextChannelById(config.getMatchChannel());
                 if (textChannel != null) {
                     File imgFile = new File(match.getMap().getSource().getAbsoluteDir().toFile(), "map.png");
-                    if (imgFile.exists()) {
-                        textChannel.sendFiles(FileUpload.fromData(imgFile, "map.png"))
-                                        .setEmbeds(embed.build())
-                                                .queue(message1 -> {
-                                                    matchMessageMap.put(Long.valueOf(match.getId()), message1.getIdLong());
-                                                });
-                    } else {
-                        textChannel.sendMessageEmbeds(embed.build()).queue(messageSent -> {
-                            matchMessageMap.put(Long.valueOf(match.getId()), messageSent.getIdLong());
-                        });
-                    }
+                    MessageCreateAction messageAction = (imgFile.exists()) ? textChannel.sendFiles(FileUpload.fromData(imgFile, "map.png")).setEmbeds(embed.build())
+                            : textChannel.sendMessageEmbeds(embed.build());
+                    messageAction.queue(message -> {
+                        matchMessageMap.put(Long.valueOf(match.getId()), message.getIdLong());
+                    });
                 }
             }
         }

--- a/src/main/java/me/tbg/match/bot/MatchFinishListener.java
+++ b/src/main/java/me/tbg/match/bot/MatchFinishListener.java
@@ -25,6 +25,7 @@ public class MatchFinishListener implements Listener {
 
     @EventHandler
     public void onMatchFinish(MatchFinishEvent event) {
+        BotConfig config = bot.getConfig();
         Match match = event.getMatch();
         MapInfo map = match.getMap();
         ScoreMatchModule scoreModule = match.getModule(ScoreMatchModule.class);
@@ -34,7 +35,7 @@ public class MatchFinishListener implements Listener {
         Color winnerColor = getWinnerColor(event);
 
         EmbedBuilder matchFinishEmbed =
-                createMatchFinishEmbed(match, map, winner, winnerColor, scoreModule, teamModule);
+                createMatchFinishEmbed(config, match, map, winner, winnerColor, scoreModule, teamModule);
 
         bot.editMatchEmbed(Long.parseLong(match.getId()), matchFinishEmbed);
     }
@@ -58,6 +59,7 @@ public class MatchFinishListener implements Listener {
     }
 
     private EmbedBuilder createMatchFinishEmbed(
+            BotConfig config,
             Match match,
             MapInfo map,
             String winner,
@@ -98,7 +100,7 @@ public class MatchFinishListener implements Listener {
                 .addField("Participants", String.valueOf(match.getParticipants().size()), true)
                 .addField("Observers", String.valueOf(match.getDefaultParty().getPlayers().size()), true)
                 .addField("Staff", String.valueOf(bot.getOnlineStaffCount(match)), true)
-                .setFooter("Map tags: " + map.getTags().toString());
+                .setFooter((!config.getServerName().isEmpty() ? "Server: " + config.getServerName() + " • " : "") + "Map tags: " + map.getTags().toString());
 
         bot.setEmbedThumbnail(map, embed, bot);
 

--- a/src/main/java/me/tbg/match/bot/MatchStartListener.java
+++ b/src/main/java/me/tbg/match/bot/MatchStartListener.java
@@ -23,7 +23,7 @@ public class MatchStartListener implements Listener {
     public void onMatchStart(MatchStartEvent event) {
         Match match = event.getMatch();
         MapInfo map = match.getMap();
-        EmbedBuilder matchStartEmbed = createMatchStartEmbed(match, map);
+        EmbedBuilder matchStartEmbed = createMatchStartEmbed(match, map, bot.getConfig());
 
         bot.setEmbedThumbnail(map, matchStartEmbed, bot);
         bot.sendMatchEmbed(matchStartEmbed, match);
@@ -33,7 +33,7 @@ public class MatchStartListener implements Listener {
                 match.getPlayers().size());
     }
 
-    private EmbedBuilder createMatchStartEmbed(Match match, MapInfo map) {
+    private EmbedBuilder createMatchStartEmbed(Match match, MapInfo map, BotConfig config) {
         return new EmbedBuilder()
                 .setColor(Color.WHITE.getRGB())
                 .setTitle("Match #" + match.getId() + " has started!")
@@ -45,6 +45,8 @@ public class MatchStartListener implements Listener {
                 .addField("Pools", bot.getMapPools(match), true)
                 .addField("Objective", map.getDescription(), false)
                 .addField("Participants", String.valueOf(match.getParticipants().size()), true)
-                .addField("Observers", String.valueOf(match.getDefaultParty().getPlayers().size()), true);
+                .addField("Observers", String.valueOf(match.getDefaultParty().getPlayers().size()), true)
+                .setFooter((!config.getServerName().isEmpty() ? "Server: " + config.getServerName() + " • " : "") + "Map tags: " + map.getTags().toString());
+
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,16 +1,13 @@
-# Discord Stuff
-enabled: true # Enable discord bot?
+# MatchBot configuration file
+# Discord settings
+enabled: true # Enable Discord bot?
 token: "" # Discord bot token
-server: "" # ID of discord server
+server: "" # ID of Discord server
+match-channel: "" # ID of channel where match embeds will be sent
 
-# ID of channel where match embeds will be sent
-match-channel: ""
+# Minecraft settings
+server-name: "" # Name of the server (useful for networks)
 
-# Fallback URL for map.png images
-# This will be used in case no map.png is found the map's directory
-# Example: https://raw.githubusercontent.com/TBG1000/MapImages/main/Maps/
-fallback-map-images: ""
-
-# Image URL to display in the embed's thumbnail if no image is found
+# Image URL to display in the embed's thumbnail if a map image is not found
 # Example: https://raw.githubusercontent.com/TBG1000/MapImages/main/map_image_not_found.png
 map-image-not-found: ""

--- a/src/main/resources/paper-plugin.yml
+++ b/src/main/resources/paper-plugin.yml
@@ -1,0 +1,14 @@
+name: ${project.name}
+description: ${project.description}
+version: '${project.version}'
+api-version: '1.21.10'
+main: me.tbg.match.bot.MatchBot
+author: TBG1000
+website: https://github.com/TBG1000/MatchBot
+
+dependencies:
+  server:
+    PGM:
+      load: BEFORE
+      required: true
+      join-classpath: true

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,7 @@
-name: MatchBot
-main: me.tbg.match.bot.MatchBot
-description: A Minecraft to Discord bot. Display PGM match information in Discord.
+name: ${project.name}
+description: ${project.description}
 version: ${project.version}
+main: me.tbg.match.bot.MatchBot
 author: TBG1000
+website: https://github.com/TBG1000/MatchBot
 depend: [PGM]


### PR DESCRIPTION
Updated Matchbot to use modern JDA version

- Added paper-plugin.yml to handle plugin running with modern versions of PGM. 
- Added extra config option "server-name" to allow for distinction of matches running on Classic and Modern. Bot status displays server name if provided
- Removed config option "get-fallback-map-images"